### PR TITLE
Simplify asset owner field to MSPID/user

### DIFF
--- a/applications/trader-typescript/src/transfer.ts
+++ b/applications/trader-typescript/src/transfer.ts
@@ -11,8 +11,8 @@ import { assertDefined } from './utils';
 
 export default async function main(gateway: Gateway, args: string[]): Promise<void> {
     const assetId = assertDefined(args[0], 'Missing asset ID');
-    const newOwner = assertDefined(args[1], 'Missing new owner');
-    const newOwnerOrg = assertDefined(args[2], 'Missing new owner org');
+    const newOwner = assertDefined(args[1], 'Missing new owner name');
+    const newOwnerOrg = assertDefined(args[2], 'Missing new owner MSP ID');
 
     const network = gateway.getNetwork(channelName);
     const contract = network.getContract(chaincodeName);


### PR DESCRIPTION
Previously the entire certificate subject and issuer details were used, which was too cumbersome.