### PR TITLE
Minor refinements to application developement documentation

### DIFF
--- a/docs/ApplicationDev/04-Exercise-AssetTransfer.md
+++ b/docs/ApplicationDev/04-Exercise-AssetTransfer.md
@@ -5,7 +5,15 @@ Currently, our trader application can only create and delete assets. To really b
 There is already a **transfer** command implemented in [transfer.ts](../../applications/trader-typescript/src/commands/transfer.ts), which calls the `transferAsset()` method on our **AssetTransfer** class. Unfortunately, this has not yet been implemented and does nothing.
 
 1. Write an implementation for the `transferAsset()` method in [contract.ts](../../applications/trader-typescript/src/contract.ts). Look at the [API documentation for Contract](https://hyperledger.github.io/fabric-gateway/main/api/node/interfaces/Contract.html) and other methods within the **AssetTransfer** class for ideas on how to proceed.
+
+1. Recompile the application from your updated TypeScript:
+    ```bash
+    npm install
+    ```
+    > **Tip:** You can also leave `npm run build:watch` running in a terminal window to automatically rebuild your application on any code change.
+
 1. Try it out! Use the **transfer** command to transfer assets to new owners with the same MSP ID.
+
 1. What happens if you try to manipulate (transfer, delete) an asset after transferring it to another MSP ID?
 
 The smart contract contains logic that only allows users in the owning organization to modify assets. It does this by checking that the Member Services Provider (MSP) ID for the client identity invoking the transaction matches the organization MSP ID of the asset owner. If you didn't notice this before, you might want to check out the smart contract code to see how this is implemented.

--- a/docs/ApplicationDev/06-Exercise-ChaincodeEvents.md
+++ b/docs/ApplicationDev/06-Exercise-ChaincodeEvents.md
@@ -3,6 +3,7 @@
 First, let's try listening for chaincode events to see what information is included in events emitted by the smart contract transaction functions.
 
 1. Run the **listen** command to listen for chaincode events. Once you have received the available events, interrupt the application using `Control-C`.
+
 1. Run the **listen** command again. What do we see this time?
 
 On the second run of the **listen** command, you should have seen exactly the same output as the first run. This is because each run of the **listen** command retrieves all chaincode events from start of the blockchain. That's not so useful if we want to invoke external business processes in response to chaincode events. It would be much better if each event was received exactly once, regardless of whether the client application is restarted.
@@ -10,10 +11,12 @@ On the second run of the **listen** command, you should have seen exactly the sa
 Let's implement checkpointing to ensure there are no duplicate or missed events.
 
 3. Implement checkpointing for the reading of chaincode events in [listen.ts](../../applications/trader-typescript/src/commands/listen.ts). Look at the [API documentation for Network](https://hyperledger.github.io/fabric-gateway/main/api/node/interfaces/Network.html) for ideas on how to proceed. Be sure to only checkpoint events *after* they are successfully processed!
-1. Run the **listen** with the SIMULATED_FAILURE_COUNT environment variable set to simulate an application error during the processing of a chancode event:
+
+1. Ensure your changes are compiled, then run the **listen** command with the SIMULATED_FAILURE_COUNT environment variable set to simulate an application error during the processing of a chancode event:
     ```bash
     SIMULATED_FAILURE_COUNT=3 npm start listen
     ```
+
 1. Run the **listen** command again. You should see event listening resume from the same chaincode event that the application failed to process on the previous run.
 
 > **Note:** The checkpointer persists its current listening position in a `checkpoint.json` file. If you want to remove the checkpointer's stored state and start listening from the `startBlock` again, remove the `checkpoint.json` file while the checkpointer is not in use.
@@ -23,4 +26,5 @@ Let's implement checkpointing to ensure there are no duplicate or missed events.
 So far we have been replaying previously emitted chaincode events. Let's use the **listen** command to notify us in realtime when we take ownership of assets.
 
 6. Modify the **onEvent()** function in [listen.ts](../../applications/trader-typescript/src/commands/listen.ts) to notify you if you become the owner of a new (`CreateAsset` event) or transferred (`TransferAsset` event) asset. Note that the `payload` property of the event is a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) containing the [JSON](https://en.wikipedia.org/wiki/JSON) emitted by the smart contract. Look at the **readAsset()** method in [contract.ts](../../applications/trader-typescript/src/contract.ts) for ideas on how to convert this into a JavaScript object so you can inspect its `Owner` property.
+
 1. Try running the **listen** command in one terminal window while using another terminal window to create and transfer assets.


### PR DESCRIPTION
Explicitly call out the compile step to avoid the gotcha of running an old version of the code after making code changes.