### PR TITLE
fix broken build: allow kubectl client >= 1.24

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -39,7 +39,7 @@ else
 
   KUBECTL_CLIENT_VERSION=$(kubectl version --client --output=yaml | grep gitVersion | cut -c 15-)
   KUBECTL_CLIENT_MINOR_VERSION=$(kubectl version --client --output=yaml | grep minor | cut -c 11-12)
-  if [ ${KUBECTL_CLIENT_MINOR_VERSION} != "24" ]; then
+  if [ "${KUBECTL_CLIENT_MINOR_VERSION}" -lt "24" ]; then
     echo -e "${WARN} Found kubectl client version ${KUBECTL_CLIENT_VERSION}, which may be out of date.  Please ensure client version >= ${KUBECTL_VERSION}"
     EXIT=1
   fi


### PR DESCRIPTION
k8s bumped the minor rev of `kubectl` over the weekend (?)  

This update does a better job of passing `./check.sh` for kubectl >= 1.24 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>