### PR TITLE
Add a check that the peer CLI actually runs on the target OS

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -126,6 +126,15 @@ then
   EXIT=1
 else
   echo -e "${SUCCESS} peer found:\t\t$(cat /tmp/cmdpath)"
+
+  # double-check that the peer binary is compiled for the correct arch.  This can occur when installing fabric
+  # binaries into a multipass VM, then running the Linux binaries from a Mac or windows Host OS via the volume share.
+  bin/peer version &> /dev/null
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo -e "${WARN}  Could not execute bin/peer.  Was it compiled for the correct architecture?"
+    bin/peer version
+  fi
 fi
 
 # tests if varname is defined in the env AND it's an existing directory


### PR DESCRIPTION
Test the `peer` CLI by running it in check.sh.

This catches a case where the binaries were installed in the MP VM, then executed from the host OS on a different arch. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>