### PR TITLE
Update 40-bananas.md

### DIFF
--- a/docs/CloudReady/40-bananas.md
+++ b/docs/CloudReady/40-bananas.md
@@ -128,6 +128,7 @@ To set up a load-balanced Gateway [Service and Ingress](../../infrastructure/sam
 
 - Create a virtual host name / Ingress endpoint for the org peers: 
 ```shell
+pushd applications/trader-typescript
 
 kubectl kustomize \
   ../../infrastructure/sample-network/config/gateway \
@@ -145,6 +146,7 @@ export ENDPOINT=${WORKSHOP_NAMESPACE}-org1-peer-gateway.${WORKSHOP_INGRESS_DOMAI
 
 npm start getAllAssets
 
+popd
 ```
 
 Note that in order to support ingress and host access with the new virtual domain, the peer 


### PR DESCRIPTION
Ensure user is in the application folder before running the commands that are location sensitive. The `popd` command at the end of the previous section leaves the user in the top directory which leads to have the following ones fail.