### PR TITLE
Fix chaincode bug, and Minor code, doc and .gitignore tidy-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ _*
 ~*.pptx
 
 bin
-./config/
-./config/multipass-kube-config.yaml
+config/
 
 .DS_Store
 .idea/

--- a/contracts/asset-transfer-typescript/.gitignore
+++ b/contracts/asset-transfer-typescript/.gitignore
@@ -14,3 +14,6 @@ npm-shrinkwrap.json
 
 # Compiled TypeScript files
 dist
+
+# Files created during workshop run
+metadata.json

--- a/contracts/asset-transfer-typescript/src/asset.ts
+++ b/contracts/asset-transfer-typescript/src/asset.ts
@@ -2,52 +2,44 @@
   SPDX-License-Identifier: Apache-2.0
 */
 
-// export interface Asset {
-//     docType?: string;
-//     ID: string;
-//     Color: string;
-//     Size: number;
-//     Owner: string;
-//     AppraisedValue: number;
-// }
-
-
-import {Object as DataType, Property } from 'fabric-contract-api';
+import { Object as DataType, Property } from 'fabric-contract-api';
 
 @DataType()
 export class Asset {
     @Property('ID', 'string')
-        ID ='';
+    ID = '';
 
     @Property('Color', 'string')
-        Color='';
+    Color = '';
 
     @Property('Owner', 'string')
-        Owner='';
+    Owner = '';
 
     @Property('AppraisedValue', 'number')
-        AppraisedValue=0;
+    AppraisedValue = 0;
 
     @Property('Size', 'number')
-        Size=0;
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    public constructor() {}
+    Size = 0;
 
-    static newAsset(state: Partial<Asset> = {}): Asset {
+    constructor() {
+        // Nothing to do
+    }
+
+    static newInstance(state: Partial<Asset> = {}): Asset {
         return {
-            ID: Asset.assertHasValue(state.ID, 'Missing ID'),
+            ID: assertHasValue(state.ID, 'Missing ID'),
             Color: state.Color ?? '',
             Size: state.Size ?? 0,
-            Owner: Asset.assertHasValue(state.Owner, 'Missing Owner'),
+            Owner: assertHasValue(state.Owner, 'Missing Owner'),
             AppraisedValue: state.AppraisedValue ?? 0,
         };
     }
+}
 
-    static assertHasValue<T>(value: T | undefined | null, message: string): T {
-        if (value == undefined || typeof value === 'string' && value.length === 0) {
-            throw new Error(message);
-        }
-
-        return value;
+function assertHasValue<T>(value: T | undefined | null, message: string): T {
+    if (value == undefined || (typeof value === 'string' && value.length === 0)) {
+        throw new Error(message);
     }
+
+    return value;
 }

--- a/docs/ApplicationDev/02-Exercise-RunApplication.md
+++ b/docs/ApplicationDev/02-Exercise-RunApplication.md
@@ -41,12 +41,3 @@ These application CLI commands represent a simplified application that performs 
 Try using the **create**, **read** and **delete** commands to work with specific assets.
 
 See the application [Readme](../../applications/trader-typescript/README.md) for details on how to use the commands.
-
-The environment variable settings above run as a user from org1. If you want to run as a user from org2, use these environment variables:
-
-```bash
-export ENDPOINT=org2peer-api.127-0-0-1.nip.io:8080
-export MSP_ID=org2MSP
-export CERTIFICATE=../../_cfg/uf/_msp/org2/org2admin/msp/signcerts/org2admin.pem
-export PRIVATE_KEY=../../_cfg/uf/_msp/org2/org2admin/msp/keystore/cert_sk
-```


### PR DESCRIPTION
- Update of the chaincode to use data type annotations for Asset objects broke the logic to generate asset owner on CreateAsset since, if no owner was supplied, a default empty string value is set instead of an undefined value. Change implementation to use the identity common name if the owner is an empty string (or undefined).
- Some files created when running the workshop were not included in .gitignore.
- Remove information for running an org2MSP from running the application instructions since the microfab deployment doesn't actually contain a usable org2.