### PR TITLE
Fixes to a few scripts 

### DIFF
--- a/applications/ping-chaincode/app.env
+++ b/applications/ping-chaincode/app.env
@@ -4,3 +4,4 @@ CONN_PROFILE_FILE=/home/matthew/github.com/hyperledgendary/full-stack-asset-tran
 ID_FILE=asset-transfer_appid.json
 ID_DIR=/home/matthew/github.com/hyperledgendary/full-stack-asset-transfer-guide/_cfg/
 TLS_ENABLED=true
+MSPID=Org1MSP

--- a/applications/ping-chaincode/src/app.ts
+++ b/applications/ping-chaincode/src/app.ts
@@ -22,6 +22,7 @@ const chaincodeName = env.get('CHAINCODE_NAME').default('conga-nft-contract').as
 const connectionProfile = env.get('CONN_PROFILE_FILE').required().asString();
 const identityFile = env.get('ID_FILE').required().asString()
 const identityDir = env.get('ID_DIR').required().asString()
+const mspID = env.get('MSPID').required().asString()
 const tls = env.get('TLS_ENABLED').default("false").asBool();
 
 const utf8Decoder = new TextDecoder();
@@ -36,7 +37,7 @@ async function main(): Promise<void> {
     const client = await ConnectionHelper.newGrpcConnection(cp,tls);
     console.log("Created GRPC Connection")
 
-    const jsonAdapter: JSONIDAdapter = new JSONIDAdapter(path.resolve(identityDir),'Org1MSP');
+    const jsonAdapter: JSONIDAdapter = new JSONIDAdapter(path.resolve(identityDir),mspID);
     const identity = await jsonAdapter.getIdentity(identityFile);
     const signer = await jsonAdapter.getSigner(identityFile);
 

--- a/check.sh
+++ b/check.sh
@@ -138,11 +138,11 @@ else
 
   # double-check that the peer binary is compiled for the correct arch.  This can occur when installing fabric
   # binaries into a multipass VM, then running the Linux binaries from a Mac or windows Host OS via the volume share.
-  bin/peer version &> /dev/null
+  peer version &> /dev/null
   rc=$?
   if [ $rc -ne 0 ]; then
-    echo -e "${WARN}  Could not execute bin/peer.  Was it compiled for the correct architecture?"
-    bin/peer version
+    echo -e "${WARN}  Could not execute peer.  Was it compiled for the correct architecture?"
+    peer version
   fi
 fi
 

--- a/contracts/asset-transfer-typescript/Dockerfile
+++ b/contracts/asset-transfer-typescript/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:16 AS builder
+FROM node:16.14 AS builder
 
 WORKDIR /usr/src/app
 
@@ -12,7 +12,7 @@ RUN npm install
 RUN npm run build && npm shrinkwrap
 
 
-FROM node:16 as prod-builder
+FROM node:16.14 as prod-builder
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=builder /usr/src/app/dist ./dist
 COPY --chown=node:node --from=builder /usr/src/app/package.json ./
@@ -21,7 +21,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # ------------------------------------------------------------------------------
 # Builds the Chaincode as a Service docker version
-FROM node:16 AS ccaas
+FROM node:16.14 AS ccaas
 WORKDIR /usr/src/app
 
 COPY --chown=node:node --from=prod-builder /usr/src/app .
@@ -44,7 +44,7 @@ ENTRYPOINT [ "/tini", "--", "/usr/src/app/docker-entrypoint.sh" ]
 
 # ------------------------------------------------------------------------------
 # Builds the chaincode for the k8s builder
-FROM node:16 AS k8s
+FROM node:16.14 AS k8s
 WORKDIR /usr/src/app
 
 COPY --chown=node:node --from=prod-builder /usr/src/app .


### PR DESCRIPTION
While testing deployment on OpenShift, I found a few issues:  
  
* Updated justfile to leverage the latest blockchain ansible image and to ensure the chaincode build works with both OpenShift and local deployment.  
* Fixed the `check.sh` so that the Architecture check uses the peer from the `$PATH` as opposed to assuming it is in the `bin` directory.  
* For the `ping-chaincode` application removed the hardcoded `Org1MSP` and replaced by a variable defined in the `app.env` file.  
* Typescript chaincode build pulls node v16.17 which then cause the container to fail with an error code 243.  Downgraded the node version to v16.14 to resolve the issue.
